### PR TITLE
Use next callback to implement middlewares

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -114,6 +114,9 @@ object examples extends Module {
   object async extends Common with UsesCore {
     def moduleDeps = super.moduleDeps :+ `snunit-scala-native-loop`
   }
+  object `async-multiple-handlers` extends Common with UsesCore {
+    def moduleDeps = super.moduleDeps :+ `snunit-scala-native-loop`
+  }
 }
 
 object integration extends ScalaModule {

--- a/examples/async-multiple-handlers/src/snunit/examples/MultipleHandlersExample.scala
+++ b/examples/async-multiple-handlers/src/snunit/examples/MultipleHandlersExample.scala
@@ -1,0 +1,31 @@
+package snunit.examples
+
+import snunit._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object MultipleHandlersExample {
+  def main(args: Array[String]): Unit = {
+    AsyncServerBuilder()
+      .withRequestHandler(req =>
+        global.execute(new Runnable {
+          def run(): Unit = {
+            if (req.method == Method.GET) {
+              req.send(
+                statusCode = 200,
+                content = s"Hello world async multiple handlers!\n",
+                headers = Seq("Content-Type" -> "text/plain")
+              )
+            } else req.next()
+          }
+        })
+      )
+      .withRequestHandler(req => {
+        req.send(
+          statusCode = 404,
+          content = s"Not found\n",
+          headers = Seq("Content-Type" -> "text/plain")
+        )
+      })
+      .build()
+  }
+}

--- a/examples/multiple-handlers/src/snunit/examples/MultipleHandlersExample.scala
+++ b/examples/multiple-handlers/src/snunit/examples/MultipleHandlersExample.scala
@@ -7,13 +7,14 @@ object MultipleHandlersExample {
     val server =
       SyncServerBuilder()
         .withRequestHandler(req => {
-          if (req.method == Method.GET)
+          if (req.method == Method.GET) {
             req.send(
               statusCode = 200,
               content = s"Hello world multiple handlers!\n",
               headers = Seq("Content-Type" -> "text/plain")
             )
-          else false
+          }
+          else req.next()
         })
         .withRequestHandler(req => {
           req.send(
@@ -21,7 +22,6 @@ object MultipleHandlersExample {
             content = s"Not found\n",
             headers = Seq("Content-Type" -> "text/plain")
           )
-          false
         })
         .build()
 

--- a/integration/test/src/ExamplesTest.scala
+++ b/integration/test/src/ExamplesTest.scala
@@ -31,6 +31,19 @@ object ExamplesTest extends TestSuite {
         assert(postResultResponse.statusCode == 404)
       }
     }
+    test("async-multiple-handlers") {
+      withDeployedExample("async-multiple-handlers") {
+        val getResult = requests.get(baseUrl).text()
+        val expectedGetResult = "Hello world async multiple handlers!\n"
+        assert(getResult == expectedGetResult)
+
+        val postResultResponse = requests.post(baseUrl, check = false)
+        val postResult = postResultResponse.text()
+        val expectedPostResult = "Not found\n"
+        assert(postResult == postResult)
+        assert(postResultResponse.statusCode == 404)
+      }
+    }
     test("autowire") {
       withDeployedExample("autowire") {
         val name = "A-Name"

--- a/snunit-scala-native-loop/src/snunit/AsyncServerBuilder.scala
+++ b/snunit-scala-native-loop/src/snunit/AsyncServerBuilder.scala
@@ -34,8 +34,8 @@ object AsyncServerBuilder {
 }
 
 class AsyncServerBuilder(
-    private val requestHandlers: Seq[Request => Boolean],
-    private val websocketHandlers: Seq[WSFrame => Boolean]
+    private val requestHandlers: Seq[Request => Unit],
+    private val websocketHandlers: Seq[WSFrame => Unit]
 ) extends ServerBuilder(requestHandlers, websocketHandlers) {
   def this() = this(Seq.empty, Seq.empty)
 
@@ -50,8 +50,8 @@ class AsyncServerBuilder(
   }
 
   protected override def create(
-      requestHandlers: Seq[Request => Boolean],
-      websocketHandlers: Seq[WSFrame => Boolean]
+      requestHandlers: Seq[Request => Unit],
+      websocketHandlers: Seq[WSFrame => Unit]
   ): this.type =
     new AsyncServerBuilder(requestHandlers, websocketHandlers).asInstanceOf[this.type]
 }

--- a/snunit/src/snunit/ServerBuilder.scala
+++ b/snunit/src/snunit/ServerBuilder.scala
@@ -1,23 +1,23 @@
 package snunit
 
 import scala.scalanative.unsafe._
-import snunit.unsafe.DataUtils
+import snunit.unsafe.PtrUtils
 import snunit.unsafe.CApi._
 import snunit.unsafe.CApiOps._
 
 abstract class ServerBuilder protected (
-    private val requestHandlers: Seq[Request => Boolean],
-    private val websocketHandlers: Seq[WSFrame => Boolean]
+    private val requestHandlers: Seq[Request => Unit],
+    private val websocketHandlers: Seq[WSFrame => Unit]
 ) {
-  def withRequestHandler(handler: Request => Boolean): this.type = {
+  def withRequestHandler(handler: Request => Unit): this.type = {
     copy(requestHandlers = requestHandlers :+ handler)
   }
-  def withWebsocketHandler(handler: WSFrame => Boolean): this.type = {
+  def withWebsocketHandler(handler: WSFrame => Unit): this.type = {
     copy(websocketHandlers = websocketHandlers :+ handler)
   }
   private def copy(
-      requestHandlers: Seq[Request => Boolean] = requestHandlers,
-      websocketHandlers: Seq[WSFrame => Boolean] = websocketHandlers
+      requestHandlers: Seq[Request => Unit] = requestHandlers,
+      websocketHandlers: Seq[WSFrame => Unit] = websocketHandlers
   ): this.type =
     create(
       requestHandlers = requestHandlers,
@@ -26,10 +26,10 @@ abstract class ServerBuilder protected (
 
   def build(): Server
 
-  protected def create(requestHandlers: Seq[Request => Boolean], websocketHandlers: Seq[WSFrame => Boolean]): this.type
+  protected def create(requestHandlers: Seq[Request => Unit], websocketHandlers: Seq[WSFrame => Unit]): this.type
 
   protected def setBaseHandlers(init: Ptr[nxt_unit_init_t]): Unit = {
-    DataUtils.setData(init, this)
+    init.data = PtrUtils.toPtr(this)
     init.callbacks.request_handler = ServerBuilder.request_handler
     init.callbacks.websocket_handler = ServerBuilder.websocket_handler
     init.callbacks.quit = ServerBuilder.quit
@@ -39,23 +39,15 @@ abstract class ServerBuilder protected (
 object ServerBuilder {
   protected[snunit] val request_handler: request_handler_t = new request_handler_t {
     def apply(req: Ptr[nxt_unit_request_info_t]): Unit = {
-      val builder = DataUtils.getData[ServerBuilder](req)
-      val it = builder.requestHandlers.iterator
-      var handled = false
-      while (!handled && it.hasNext) {
-        handled = it.next().apply(new Request(req))
-      }
+      val builder = PtrUtils.fromPtr[ServerBuilder](req.unit.data)
+      new Request(req).runHandler(builder.requestHandlers)
     }
   }
 
   protected[snunit] val websocket_handler: websocket_handler_t = new websocket_handler_t {
     def apply(frame: Ptr[nxt_unit_websocket_frame_t]): Unit = {
-      val builder = DataUtils.getData[ServerBuilder](frame.req)
-      val it = builder.websocketHandlers.iterator
-      var handled = false
-      while (!handled && it.hasNext) {
-        handled = it.next().apply(new WSFrame(frame))
-      }
+      val builder = PtrUtils.fromPtr[ServerBuilder](frame.req.unit.data)
+      new WSFrame(frame).runHandler(builder.websocketHandlers)
     }
   }
 

--- a/snunit/src/snunit/SyncServerBuilder.scala
+++ b/snunit/src/snunit/SyncServerBuilder.scala
@@ -3,7 +3,7 @@ package snunit
 import scala.collection.mutable
 import scala.scalanative.unsafe._
 import scala.scalanative.libc.stdlib.malloc
-import snunit.unsafe.DataUtils
+import snunit.unsafe.PtrUtils
 import snunit.unsafe.CApi._
 import snunit.unsafe.CApiOps._
 
@@ -11,8 +11,8 @@ object SyncServerBuilder {
   def apply(): SyncServerBuilder = new SyncServerBuilder()
 }
 class SyncServerBuilder private (
-    private val requestHandlers: Seq[Request => Boolean],
-    private val websocketHandlers: Seq[WSFrame => Boolean]
+    private val requestHandlers: Seq[Request => Unit],
+    private val websocketHandlers: Seq[WSFrame => Unit]
 ) extends ServerBuilder(requestHandlers, websocketHandlers) {
   def this() = this(requestHandlers = Seq.empty, websocketHandlers = Seq.empty)
 
@@ -25,7 +25,7 @@ class SyncServerBuilder private (
   }
 
   protected override def create(
-      requestHandlers: Seq[Request => Boolean],
-      websocketHandlers: Seq[WSFrame => Boolean]
+      requestHandlers: Seq[Request => Unit],
+      websocketHandlers: Seq[WSFrame => Unit]
   ): this.type = new SyncServerBuilder(requestHandlers, websocketHandlers).asInstanceOf[this.type]
 }

--- a/snunit/src/snunit/unsafe/DataUtils.scala
+++ b/snunit/src/snunit/unsafe/DataUtils.scala
@@ -8,17 +8,17 @@ import scala.collection.mutable
 import snunit.unsafe.CApi._
 import snunit.unsafe.CApiOps._
 
-private[snunit] object DataUtils {
+private[snunit] object PtrUtils {
   private val references = mutable.Set.empty[Long]
 
-  @inline def getData[T <: Object](data: Ptr[nxt_unit_request_info_t]): T = {
-    val rawptr = toRawPtr(data.unit.data)
+  @inline def fromPtr[T <: Object](data: Ptr[Byte]): T = {
+    val rawptr = toRawPtr(data)
     castRawPtrToObject(rawptr).asInstanceOf[T]
   }
-  @inline def setData[T <: Object](data: Ptr[nxt_unit_init_t], obj: T): Unit = {
+  @inline def toPtr[T <: Object](obj: T): Ptr[Byte] = {
     val rawptr = castObjectToRawPtr(obj)
     val dataLong = castRawPtrToLong(rawptr)
     references += dataLong
-    data.data = fromRawPtr(rawptr)
+    fromRawPtr(rawptr)
   }
 }


### PR DESCRIPTION
- Now the requestHandler and websocketHandler callbacks don't
  return a "continue" boolean but expose a next() function to skip
  to the next handler. This allows to decide asynchronously if you
  want to skip or not. Being forced to return a boolean made the
  decision synchronous.
- Add a integration test to check that `next` works asynchronously