### PR TITLE
Implement handlers composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,14 @@ val details  = Root / "details" / Arg[Int]
 val userInfo = Root / "user" / Arg[String] & Param[Boolean]("show")
 
 AsyncServerBuilder()
-  .withRoute(details) { case (req, details) =>
-    req.send(200, details, Seq.empty)
-  }
-  .withRoute(userInfo) { case (req, (user, show)) =>
+  .withRequestHandler(
+    _.withMethod(Method.GET)
+      .withRoute(details) { case (req, details) =>
+        req.send(200, details, Seq.empty)
+      }
+  )
+  .withRequestHandler(_.withRoute(userInfo) { case (req, (user, show)) =>
     req.send(200, s"User: $user, show: $show", Seq.empty)
-  }
+  })
   .build()
 ```

--- a/build.sc
+++ b/build.sc
@@ -156,6 +156,9 @@ object integration extends ScalaModule {
       def moduleDeps = Seq(`snunit-routes`)
       def ivyDeps = T { super.ivyDeps() ++ Seq(upickle) }
     }
+    object `handlers-composition` extends Common {
+      def moduleDeps = Seq(snunit)
+    }
   }
   def scalaVersion = "2.13.4"
   object test extends Tests {

--- a/integration/test/src/MainTest.scala
+++ b/integration/test/src/MainTest.scala
@@ -74,5 +74,24 @@ object MainTest extends TestSuite {
         assert(getResult == expectedGetResult)
       }
     }
+    test("handlers-composition") {
+      withDeployedExample("handlers-composition") {
+        locally {
+          val result = requests.get(baseUrl).text()
+          val expectedResult = "Hello world!\n"
+          assert(result == expectedResult)
+        }
+        locally {
+          val result = requests.post(baseUrl, check = false).text()
+          val expectedResult = "Not found!\n"
+          assert(result == expectedResult)
+        }
+        locally {
+          val result = requests.post(baseUrl + "/hello", check = false).text()
+          val expectedResult = "Not found!\n"
+          assert(result == expectedResult)
+        }
+      }
+    }
   }
 }

--- a/integration/tests/handlers-composition/src/snunit/tests/HandlersComposition.scala
+++ b/integration/tests/handlers-composition/src/snunit/tests/HandlersComposition.scala
@@ -1,30 +1,28 @@
 package snunit.tests
 
 import snunit._
-import snunit.routes._
-import trail._
 
-object Routes {
+object HandlersComposition {
   def main(args: Array[String]): Unit = {
-    val server: SyncServer =
+    val server =
       SyncServerBuilder()
         .withRequestHandler(
           _.withMethod(Method.GET)
-            .withRoute(Root / "test" / Arg[Int]) { (req, i) =>
+            .withPath("/") { req =>
               req.send(
                 statusCode = StatusCode.OK,
-                content = s"Got $i",
+                content = s"Hello world!\n",
                 headers = Seq("Content-Type" -> "text/plain")
               )
             }
         )
-        .withRequestHandler(req =>
+        .withRequestHandler { req =>
           req.send(
             statusCode = StatusCode.NotFound,
-            content = s"Not found",
+            content = s"Not found!\n",
             headers = Seq("Content-Type" -> "text/plain")
           )
-        )
+        }
         .build()
 
     server.listen()

--- a/snunit-routes/src/snunit/routes.scala
+++ b/snunit-routes/src/snunit/routes.scala
@@ -4,14 +4,14 @@ import snunit._
 import trail._
 
 object routes {
-  implicit class ServerBuilderOps[T <: ServerBuilder](private val builder: T) extends AnyVal {
-    def withRoute[Args](route: Route[Args])(handler: (Request, Args) => Unit): T = {
-      builder.withRequestHandler(req =>
-        route.parseArgs(req.path) match {
-          case Some(args) => handler(req, args)
+  implicit class RequestOps(private val req: Request) extends AnyVal {
+    def withRoute[Args](route: Route[Args])(f: (Request, Args) => Unit): Unit =
+      req.withFilter {
+        val res = route.parseArgs(req.path)
+        res match {
+          case Some(args) => f(req, args)
           case None       => req.next()
         }
-      )
-    }
+      }
   }
 }

--- a/snunit/src/snunit/Request.scala
+++ b/snunit/src/snunit/Request.scala
@@ -10,19 +10,19 @@ import snunit.unsafe.Utils._
 import snunit.unsafe.nxt_unit_sptr._
 
 class Request private[snunit] (private val req: Ptr[nxt_unit_request_info_t]) extends geny.Readable {
-  private[snunit] var nextRequested: Boolean = false
+  private var nextRequested: Boolean = false
 
   def method: Method =
     fromCStringAndSize(req.request.method, req.request.method_length) match {
       case "GET"     => Method.GET
-      case "HEAD"    => Method.HEAD
       case "POST"    => Method.POST
       case "PUT"     => Method.PUT
       case "DELETE"  => Method.DELETE
+      case "PATCH"   => Method.PATCH
+      case "HEAD"    => Method.HEAD
       case "CONNECT" => Method.CONNECT
       case "OPTIONS" => Method.OPTIONS
       case "TRACE"   => Method.TRACE
-      case "PATCH"   => Method.PATCH
       case other     => new Method(other)
     }
 

--- a/snunit/src/snunit/ServerBuilder.scala
+++ b/snunit/src/snunit/ServerBuilder.scala
@@ -42,6 +42,7 @@ object ServerBuilder {
     def apply(req: Ptr[nxt_unit_request_info_t]): Unit = {
       val builder = PtrUtils.fromPtr[ServerBuilder](req.unit.data)
       new Request(req).runHandler(builder.requestHandlers)
+      scala.scalanative.runtime.loop()
     }
   }
 


### PR DESCRIPTION
Now a request handler can be implement by chaining operators
This works as long as the method doesn't need to return anything.
For example `withMethod(method: Method)` just filters requests
and so doesn't need to return anything. `withRoute` instead returns
a `Args` so it can't implemented using this chaning operators, so
it can be used only to close a chain.
The implementation adds a boolean flag in the Request object to
allow to run `.next()` on a request and avoid running the code in
other chaining operators. To achieve this `next()` now will run
asynchronously on the event loop and it will set `nextRequested = true`
and unset it right after execution the next handler.