### PR TITLE
Add send alternative taking `statusCode: Int`

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -91,6 +91,11 @@ trait Publish extends PublishModule with Mima {
     )
   def publishVersion = VcsVersion.vcsState().format()
   def mimaPreviousVersions = Seq("0.1.0")
+  def mimaBinaryIssueFilters = Seq(
+    // snunit.Request is not meant for extension. The only
+    // valid implementations are `RequestImpl`s in this repo.
+    ProblemFilter.exclude[ReversedMissingMethodProblem]("snunit.Request.*")
+  )
 }
 trait Multiplatform extends Publish {
   override def artifactName = super.artifactName().split('-').init.mkString("-")

--- a/snunit-http4s/http4s-0.23/src/snunit/http4s/VersionSpecific.scala
+++ b/snunit-http4s/http4s-0.23/src/snunit/http4s/VersionSpecific.scala
@@ -13,7 +13,7 @@ private[http4s] object VersionSpecific {
   def writeResponse[F[_]: Async](
       req: snunit.Request,
       response: http4s.Response[F],
-      statusCode: snunit.StatusCode,
+      statusCode: Int,
       headers: Seq[(String, String)]
   ): F[Unit] = {
     Utils.sendStreaming(

--- a/snunit-http4s/http4s-1/src/snunit/http4s/VersionSpecific.scala
+++ b/snunit-http4s/http4s-1/src/snunit/http4s/VersionSpecific.scala
@@ -18,7 +18,7 @@ private[http4s] object VersionSpecific {
   def writeResponse[F[_]: Async](
       req: snunit.Request,
       response: http4s.Response[F],
-      statusCode: snunit.StatusCode,
+      statusCode: Int,
       headers: Seq[(String, String)]
   ): F[Unit] = {
     response.entity match {

--- a/snunit-http4s/shared/src/snunit/http4s/Impl.scala
+++ b/snunit-http4s/shared/src/snunit/http4s/Impl.scala
@@ -58,9 +58,8 @@ private[http4s] object Impl {
                 http4s.Response(http4s.Status.InternalServerError).putHeaders(http4s.headers.`Content-Length`.zero)
               )
               .flatMap { response =>
-                val statusCode = new snunit.StatusCode(response.status.code)
                 val headers = response.headers.headers.map { h => (h.name.toString, h.value) }
-                VersionSpecific.writeResponse(req, response, statusCode, headers)
+                VersionSpecific.writeResponse(req, response, response.status.code, headers)
               }
             dispatcher.unsafeRunAndForget(run)
           }

--- a/snunit-http4s/shared/src/snunit/http4s/Utils.scala
+++ b/snunit-http4s/shared/src/snunit/http4s/Utils.scala
@@ -9,7 +9,7 @@ private[http4s] object Utils {
   def sendStreaming[F[_]: Async](
       req: snunit.Request,
       body: http4s.EntityBody[F],
-      statusCode: snunit.StatusCode,
+      statusCode: Int,
       headers: Seq[(String, String)]
   ) = {
     req.startSend(statusCode, headers)

--- a/snunit-tapir/shared/src/snunit/tapir/SNUnitGenericServerInterpreter.scala
+++ b/snunit-tapir/shared/src/snunit/tapir/SNUnitGenericServerInterpreter.scala
@@ -141,7 +141,7 @@ private[tapir] trait SNUnitGenericServerInterpreter {
               req.send(snunit.StatusCode.NotFound, Array.emptyByteArray, Seq.empty)
             case RequestResult.Response(response) =>
               val body = response.body.getOrElse(Array.emptyByteArray)
-              req.send(new snunit.StatusCode(response.code.code), body, response.headers.map(h => h.name -> h.value))
+              req.send(response.code.code, body, response.headers.map(h => h.name -> h.value))
           }
           .handleError { case ex: Exception =>
             System.err.println(s"Error while processing the request")

--- a/snunit-undertow/src/io/undertow/io/AsyncSenderImpl.scala
+++ b/snunit-undertow/src/io/undertow/io/AsyncSenderImpl.scala
@@ -1,9 +1,8 @@
 package io.undertow.io
 
 import io.undertow.server.HttpServerExchange
-import snunit.StatusCode
 
 class AsyncSenderImpl(exchange: HttpServerExchange) extends Sender {
   def send(data: String): Unit =
-    exchange.req.send(new StatusCode(exchange.getStatusCode()), data, exchange.getResponseHeaders().asScala)
+    exchange.req.send(exchange.getStatusCode(), data.getBytes(), exchange.getResponseHeaders().asScala)
 }

--- a/snunit-undertow/src/io/undertow/server/HttpServerExchange.scala
+++ b/snunit-undertow/src/io/undertow/server/HttpServerExchange.scala
@@ -110,7 +110,7 @@ object HttpServerExchange {
           override def flush(): Unit = ???
 
           override def close(): Unit = {
-            exchange.req.send(new StatusCode(exchange.state), responseData, exchange.responseHeaders.asScala)
+            exchange.req.send(exchange.state, responseData, exchange.responseHeaders.asScala)
           }
         }
       }

--- a/snunit/jvm/src/snunit/SyncServerBuilder.scala
+++ b/snunit/jvm/src/snunit/SyncServerBuilder.scala
@@ -64,8 +64,8 @@ object SyncServerBuilder {
               def headerValue(index: Int): String = headers(index)._2
               def headerValueUnsafe(index: Int): String = headers(index)._2
               def headersLength: Int = headers.length
-              def send(statusCode: StatusCode, contentRaw: Array[Byte], headers: Seq[(String, String)]): Unit = {
-                exchange.setStatusCode(statusCode.value)
+              def send(statusCode: Int, contentRaw: Array[Byte], headers: Seq[(String, String)]): Unit = {
+                exchange.setStatusCode(statusCode)
                 val responseHeaders = exchange.getResponseHeaders()
                 headers.foreach { case (key, value) =>
                   responseHeaders.put(new HttpString(key), value)
@@ -75,7 +75,7 @@ object SyncServerBuilder {
               def sendDone(): Unit = ???
               def sendBatch(data: Array[Byte], off: Int, len: Int): Unit = ???
               def sendBatch(data: Array[Byte]): Unit = ???
-              def startSend(statusCode: snunit.StatusCode, headers: Seq[(String, String)]): Unit = ???
+              def startSend(statusCode: Int, headers: Seq[(String, String)]): Unit = ???
             })
           }
         }))

--- a/snunit/native/src/snunit/RequestImpl.scala
+++ b/snunit/native/src/snunit/RequestImpl.scala
@@ -72,7 +72,7 @@ class RequestImpl private[snunit] (private val req: Ptr[nxt_unit_request_info_t]
   }
 
   @inline
-  private def startSendUnsafe(statusCode: StatusCode, headers: Seq[(String, String)], contentLength: Int): Unit = {
+  private def startSendUnsafe(statusCode: Int, headers: Seq[(String, String)], contentLength: Int): Unit = {
     var headersLength = 0
     val fieldsSize: Int = {
       var res = 0
@@ -84,7 +84,7 @@ class RequestImpl private[snunit] (private val req: Ptr[nxt_unit_request_info_t]
     }
 
     locally {
-      val res = nxt_unit_response_init(req, statusCode.value.toShort, headersLength, fieldsSize + contentLength)
+      val res = nxt_unit_response_init(req, statusCode.toShort, headersLength, fieldsSize + contentLength)
       if (res != NXT_UNIT_OK) throw new Exception("Failed to create response")
     }
 
@@ -93,7 +93,7 @@ class RequestImpl private[snunit] (private val req: Ptr[nxt_unit_request_info_t]
     }
   }
   @inline
-  def startSend(statusCode: StatusCode, headers: Seq[(String, String)]): Unit = startSendUnsafe(statusCode, headers, 0)
+  def startSend(statusCode: Int, headers: Seq[(String, String)]): Unit = startSendUnsafe(statusCode, headers, 0)
   def sendByte(byte: Int): Unit = {
     val bytePtr = stackalloc[Byte]()
     !bytePtr = byte.toByte
@@ -133,7 +133,7 @@ class RequestImpl private[snunit] (private val req: Ptr[nxt_unit_request_info_t]
   def sendDone(): Unit = {
     nxt_unit_request_done(req, NXT_UNIT_OK)
   }
-  def send(statusCode: StatusCode, content: Array[Byte], headers: Seq[(String, String)]): Unit = {
+  def send(statusCode: Int, content: Array[Byte], headers: Seq[(String, String)]): Unit = {
     val byteArray = content.asInstanceOf[ByteArray]
     val contentLength = byteArray.length
     startSendUnsafe(statusCode, headers, contentLength)

--- a/snunit/shared/src/snunit/Request.scala
+++ b/snunit/shared/src/snunit/Request.scala
@@ -14,11 +14,19 @@ trait Request {
   def target: String
   def path: String
   def query: String
-  def send(statusCode: StatusCode, content: Array[Byte], headers: Seq[(String, String)]): Unit
+  def send(statusCode: Int, content: Array[Byte], headers: Seq[(String, String)]): Unit
+  @inline
+  def send(statusCode: StatusCode, content: Array[Byte], headers: Seq[(String, String)]): Unit = {
+    send(statusCode.value, content, headers)
+  }
   def send(statusCode: StatusCode, content: String, headers: Seq[(String, String)]): Unit = {
     send(statusCode, content.getBytes(), headers)
   }
-  def startSend(statusCode: StatusCode, headers: Seq[(String, String)]): Unit
+  @inline
+  def startSend(statusCode: StatusCode, headers: Seq[(String, String)]): Unit = {
+    startSend(statusCode.value, headers)
+  }
+  def startSend(statusCode: Int, headers: Seq[(String, String)]): Unit
   def sendBatch(data: Array[Byte]): Unit
   def sendBatch(data: Array[Byte], off: Int, len: Int): Unit
   def sendDone(): Unit


### PR DESCRIPTION
This is to avoid allocating `StatusCode` objects in http4s, tapir and other integrations