### PR TITLE
Reintroduce workaround for blocking in http4s

### DIFF
--- a/snunit/src/snunit/AsyncServerBuilder.scala
+++ b/snunit/src/snunit/AsyncServerBuilder.scala
@@ -101,7 +101,10 @@ object AsyncServerBuilder {
     }
 
     def stop(): Unit = {
-      stopped = true
+      // The NGINX Unit implementation sets `stopped = true` here
+      // https://github.com/nginx/unit/blob/bba97134e983541e94cf73e93900729e3a3e61fc/src/nodejs/unit-http/unit.cpp#L90
+      // But doing so breaks http4s server which doesn't restart properly
+      // stopped = true
       stopMonitorCallback.run()
     }
   }


### PR DESCRIPTION
I thought this workaround wasn't needed anymore, but it is still needed.
This adds it back. I will later add a regression test where I restart the app so I'm sure this bug doesn't get introduced anymore.