### PR TITLE
Make cask multithreaded by default

### DIFF
--- a/snunit-undertow/src/io/undertow/io/AsyncSenderImpl.scala
+++ b/snunit-undertow/src/io/undertow/io/AsyncSenderImpl.scala
@@ -5,5 +5,5 @@ import snunit.*
 
 class AsyncSenderImpl(exchange: HttpServerExchange) extends Sender {
   def send(data: String): Unit =
-    exchange.req.send(StatusCode(exchange.getStatusCode()), data, Headers(exchange.getResponseHeaders().asScala: _*))
+    exchange.req.send(StatusCode(exchange.getStatusCode()), data, exchange.getResponseHeaders().toSNUnitHeaders)
 }

--- a/snunit-undertow/src/io/undertow/server/HttpServerExchange.scala
+++ b/snunit-undertow/src/io/undertow/server/HttpServerExchange.scala
@@ -110,7 +110,7 @@ object HttpServerExchange {
           override def flush(): Unit = ???
 
           override def close(): Unit = {
-            exchange.req.send(StatusCode(exchange.state), responseData, Headers(exchange.responseHeaders.asScala: _*))
+            exchange.req.send(StatusCode(exchange.state), responseData, exchange.responseHeaders.toSNUnitHeaders)
           }
         }
       }

--- a/snunit-undertow/src/io/undertow/server/handlers/BlockingHandler.scala
+++ b/snunit-undertow/src/io/undertow/server/handlers/BlockingHandler.scala
@@ -5,7 +5,9 @@ import io.undertow.server._
 final class BlockingHandler(handler: HttpHandler) extends HttpHandler {
   def handleRequest(exchange: HttpServerExchange): Unit = {
     exchange.startBlocking()
-    handler.handleRequest(exchange)
-    exchange.endExchange()
+    scala.concurrent.ExecutionContext.global.execute(() =>
+      try { handler.handleRequest(exchange) }
+      finally { exchange.endExchange() }
+    )
   }
 }

--- a/snunit-undertow/src/io/undertow/server/util/HeaderMap.scala
+++ b/snunit-undertow/src/io/undertow/server/util/HeaderMap.scala
@@ -8,7 +8,16 @@ final class HeaderMap private[undertow] (underlying: collection.Map[String, Stri
   private lazy val underlyingMutable = underlying.asInstanceOf[scala.collection.mutable.Map[String, String]]
 
   def this() = this(collection.mutable.Map.empty[String, String])
-  private[undertow] def asScala = underlying.toSeq
+  private[undertow] def toSNUnitHeaders: snunit.Headers =
+    val headers = snunit.Headers(underlying.size)
+    var i = 0
+    underlying.foreach((k, v) =>
+      headers.updateName(i, k)
+      headers.updateValue(i, v)
+      i += 1
+    )
+    headers
+
   def getFirst(headerName: String): String = underlying.getOrElse(headerName, null)
   def get(headerName: String): java.util.Collection[String] = {
     val l = new java.util.ArrayList[String]()


### PR DESCRIPTION
NGINX Unit already supports managing contexts in different threads than the main thread that initialized it.
This just wraps calls to `handleRequest` in `scala.concurrent.ExecutionContext.global.execute`